### PR TITLE
Minor changes in the README and the HF adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Transformers are great, but often times, you want to finetune them for your down
 
 ```python
 from refinery.adapter import transformers
-dataset, mapping = transformers.build_dataset(client, "headline", "__clickbait")
+dataset, mapping, index = transformers.build_classification_dataset(client, "headline", "__clickbait")
 ```
 
 From here, you can follow the [finetuning example](https://huggingface.co/docs/transformers/training) provided in the official Hugging Face documentation. A next step could look as follows:

--- a/refinery/adapter/transformers.py
+++ b/refinery/adapter/transformers.py
@@ -9,7 +9,7 @@ def build_classification_dataset(
     client: Client,
     sentence_input: str,
     classification_label: str,
-    num_train: Optional[int] = 100,
+    num_train: Optional[int] = None,
 ):
     """Build a classification dataset from a refinery client and a config string useable for HuggingFace finetuning.
 


### PR DESCRIPTION
I noticed that the number of training examples for the HF was very low by default. Seemed to be that the default was set to 100. Setting it to "None" resolved this, ensuring that all weakly supervised records are used for fine-tuning. 

Also fixed some errors in the README. 